### PR TITLE
Fix appending quantity to rel attribute (accounts for variants)

### DIFF
--- a/src/ActiveCommerce.Training.ProductQuantity/skins/training/scripts/product.js
+++ b/src/ActiveCommerce.Training.ProductQuantity/skins/training/scripts/product.js
@@ -10,10 +10,20 @@
             }
             var link = ActiveCommerce.Product.Variants.$elements.addToCart;
             var url = link.attr('rel').split("/");
-            url = url.splice(5, url.length - 4);
+            url.splice(5, url.length - 4);
             url.push(val);
             link.attr('rel', url.join("/"));
         });
     };
 
 })(ActiveCommerce.Product.init);
+
+
+ActiveCommerce.Product.Variants.updateDisplay = (function (baseUpdateDisplay) {
+
+    return function () {
+        baseUpdateDisplay();
+        // Force a call to quatity change to ensure it stays in the rel attribute
+        $('#options-qty').change();
+    };
+})(ActiveCommerce.Product.Variants.updateDisplay);


### PR DESCRIPTION
Saw an issue if there are variants where the quantity kept getting appended on the end of the rel tag.
